### PR TITLE
Improved workaround for Windows compatibility

### DIFF
--- a/adapters/wasm-micro-runtime.py
+++ b/adapters/wasm-micro-runtime.py
@@ -1,0 +1,23 @@
+import argparse
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='store_true')
+parser.add_argument('--test-file', action='store')
+parser.add_argument('--arg', action='append', default=[])
+parser.add_argument('--env', action='append', default=[])
+parser.add_argument('--dir', action='append', default=[])
+
+args = parser.parse_args()
+
+if args.version:
+    subprocess.run(['iwasm', '--version'])
+    sys.exit(0)
+
+TEST_FILE=args.test_file
+PROG_ARGS=args.arg 
+ENV_ARGS=[f'--env={i}' for i in args.env]
+DIR_ARGS=[f'--dir={i}' for i in args.dir]
+
+subprocess.run(["iwasm"] + ENV_ARGS + DIR_ARGS + [TEST_FILE] + PROG_ARGS)

--- a/adapters/wasm-micro-runtime.py
+++ b/adapters/wasm-micro-runtime.py
@@ -20,4 +20,4 @@ PROG_ARGS=args.arg
 ENV_ARGS=[f'--env={i}' for i in args.env]
 DIR_ARGS=[f'--dir={i}' for i in args.dir]
 
-subprocess.run(["iwasm"] + ENV_ARGS + DIR_ARGS + [TEST_FILE] + PROG_ARGS)
+sys.exit(subprocess.run(["iwasm"] + ENV_ARGS + DIR_ARGS + [TEST_FILE] + PROG_ARGS).returncode)

--- a/adapters/wasmtime.py
+++ b/adapters/wasmtime.py
@@ -1,0 +1,23 @@
+import argparse
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='store_true')
+parser.add_argument('--test-file', action='store')
+parser.add_argument('--arg', action='append', default=[])
+parser.add_argument('--env', action='append', default=[])
+parser.add_argument('--dir', action='append', default=[])
+
+args = parser.parse_args()
+
+if args.version:
+    subprocess.run(['wasmtime', '--version'])
+    sys.exit(0)
+
+TEST_FILE=args.test_file
+PROG_ARGS=args.arg 
+ENV_ARGS=[j for i in args.env for j in ["--env", i]]
+DIR_ARGS=[j for i in args.dir for j in ["--dir", i]]
+
+subprocess.run(["wasmtime"] + ENV_ARGS + DIR_ARGS + [TEST_FILE] + PROG_ARGS)

--- a/adapters/wasmtime.py
+++ b/adapters/wasmtime.py
@@ -20,4 +20,4 @@ PROG_ARGS=args.arg
 ENV_ARGS=[j for i in args.env for j in ["--env", i]]
 DIR_ARGS=[j for i in args.dir for j in ["--dir", i]]
 
-subprocess.run(["wasmtime"] + ENV_ARGS + DIR_ARGS + [TEST_FILE] + PROG_ARGS)
+sys.exit(subprocess.run(["wasmtime"] + ENV_ARGS + DIR_ARGS + [TEST_FILE] + PROG_ARGS).returncode)

--- a/adapters/wazero.py
+++ b/adapters/wazero.py
@@ -1,0 +1,34 @@
+import argparse
+import os
+import sys
+import subprocess
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='store_true')
+parser.add_argument('--test-file', action='store')
+parser.add_argument('--arg', action='append', default=[])
+parser.add_argument('--env', action='append', default=[])
+parser.add_argument('--dir', action='append', default=[])
+
+args = parser.parse_args()
+
+if args.version:
+    version=subprocess.run(['wazero', 'version'], capture_output=True, text=True).stdout.strip()
+    if version=='dev':
+        version='0.0.0'
+    print("wazero", version)
+    sys.exit(0)
+
+TEST_FILE=args.test_file
+TEST_DIR=os.path.dirname(TEST_FILE)
+PROG_ARGS=[]
+if args.arg:
+    PROG_ARGS=['--']+args.arg
+ENV_ARGS=[j for i in args.env for j in ["-env", i]]
+cwd=os.getcwd()
+DIR_ARGS=[f"-mount={cwd}/{dir}:/{dir}" for dir in args.dir]
+
+PROG=["wazero"] + ["run", "-hostlogging=filesystem"] + ENV_ARGS + DIR_ARGS + [TEST_FILE] + PROG_ARGS
+print(PROG)
+print(TEST_DIR)
+subprocess.run(PROG, cwd=TEST_DIR)

--- a/adapters/wazero.py
+++ b/adapters/wazero.py
@@ -29,6 +29,6 @@ cwd=os.getcwd()
 DIR_ARGS=[f"-mount={cwd}/{dir}:/{dir}" for dir in args.dir]
 
 PROG=["wazero"] + ["run", "-hostlogging=filesystem"] + ENV_ARGS + DIR_ARGS + [TEST_FILE] + PROG_ARGS
-print(PROG)
-print(TEST_DIR)
-subprocess.run(PROG, cwd=TEST_DIR)
+# print(PROG)
+# print(TEST_DIR)
+sys.exit(subprocess.run(PROG, cwd=TEST_DIR).returncode)

--- a/adapters/wazero.sh
+++ b/adapters/wazero.sh
@@ -52,9 +52,8 @@ fi
 # Run the tests in the test directory because the --dir arguments are given as
 # paths relative to the test file.
 TEST_DIR=$(dirname "$TEST_FILE")
-TEST_FILE=$(basename "$TEST_FILE")
 
 cd "$TEST_DIR"
 set -x # echo the next line, useful for debugging to re-run failing tests
-exec wazero run -hostlogging filesystem "${ARGS[@]}" "$TEST_FILE" "${PROG_ARGS[@]}"
+exec wazero run -hostlogging=filesystem "${ARGS[@]}" "$TEST_FILE" "${PROG_ARGS[@]}"
 

--- a/adapters/wazero.sh
+++ b/adapters/wazero.sh
@@ -32,8 +32,7 @@ while [[ $# -gt 0 ]]; do
         shift
         ;;
     --dir)
-	# TODO: the mount should only include $2 not the basedir of it.
-        ARGS+=("-mount=${PWD}:/")
+	ARGS+=("-mount=${PWD}/${2}:/${2}")
         shift
         shift
         ;;

--- a/adapters/wazero.sh
+++ b/adapters/wazero.sh
@@ -2,12 +2,19 @@
 
 TEST_FILE=
 ARGS=()
-PROG_ARGS=()
+PROG_ARGS=("--")
 
 while [[ $# -gt 0 ]]; do
     case $1 in
     --version)
-        exec wazero version
+        # The test runner expects a version printed out in two parts, the first
+        # is the name of the runtime and the second is the version number.
+        version=$(wazero version)
+        if [ "$version" == "dev" ]; then
+            version=0.0.0
+        fi
+        echo wazero $version
+        exit 0
         ;;
     --test-file)
         TEST_FILE="$2"
@@ -36,8 +43,16 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Do not inject the "--" separator if there are no arguments, or wazero errors.
+if [ "${#PROG_ARGS[@]}" -eq 1 ]; then
+    PROG_ARGS=()
+fi
+
+# Run the tests in the test directory because the --dir arguments are given as
+# paths relative to the test file.
 TEST_DIR=$(dirname "$TEST_FILE")
 TEST_FILE=$(basename "$TEST_FILE")
 
 cd "$TEST_DIR"
-exec wazero run -hostlogging filesystem "${ARGS[@]}" "$TEST_FILE" -- "${PROG_ARGS[@]}"
+set -x # echo the next line, useful for debugging to re-run failing tests
+exec wazero run -hostlogging filesystem "${ARGS[@]}" "$TEST_FILE" "${PROG_ARGS[@]}"

--- a/adapters/wazero.sh
+++ b/adapters/wazero.sh
@@ -32,7 +32,8 @@ while [[ $# -gt 0 ]]; do
         shift
         ;;
     --dir)
-        ARGS+=("-mount" "$2")
+	# TODO: the mount should only include $2 not the basedir of it.
+        ARGS+=("-mount=${PWD}:/")
         shift
         shift
         ;;
@@ -56,3 +57,4 @@ TEST_FILE=$(basename "$TEST_FILE")
 cd "$TEST_DIR"
 set -x # echo the next line, useful for debugging to re-run failing tests
 exec wazero run -hostlogging filesystem "${ARGS[@]}" "$TEST_FILE" "${PROG_ARGS[@]}"
+

--- a/adapters/wazero.sh
+++ b/adapters/wazero.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+TEST_FILE=
+ARGS=()
+PROG_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    --version)
+        exec wazero version
+        ;;
+    --test-file)
+        TEST_FILE="$2"
+        shift
+        shift
+        ;;
+    --arg)
+        PROG_ARGS+=("$2")
+        shift
+        shift
+        ;;
+    --env)
+        ARGS+=("-env" "$2")
+        shift
+        shift
+        ;;
+    --dir)
+        ARGS+=("-mount" "$2")
+        shift
+        shift
+        ;;
+    *)
+        echo "Unknown option $1"
+        exit 1
+        ;;
+    esac
+done
+
+TEST_DIR=$(dirname "$TEST_FILE")
+TEST_FILE=$(basename "$TEST_FILE")
+
+cd "$TEST_DIR"
+exec wazero run -hostlogging filesystem "${ARGS[@]}" "$TEST_FILE" -- "${PROG_ARGS[@]}"

--- a/test-runner/requirements/common.txt
+++ b/test-runner/requirements/common.txt
@@ -1,1 +1,1 @@
-colorama==0.4.3
+colorama>=0.4.3

--- a/test-runner/wasi_test_runner/runtime_adapter.py
+++ b/test-runner/wasi_test_runner/runtime_adapter.py
@@ -1,6 +1,5 @@
 import subprocess
-import sys
-import os
+from shutil import which
 from pathlib import Path
 from typing import Dict, NamedTuple, List
 
@@ -17,7 +16,7 @@ class RuntimeAdapter:
         self._adapter_path = self._abs(adapter_path)
         # invoke the adapter with a configured shell runner. Default to bash.
         # e.g. this is needed to point GHA's Windows runner to bash executable
-        self._shell = os.environ.get('TEST_SHELL_RUNNER', 'bash')
+        self._shell = which('bash')
 
     def get_version(self) -> RuntimeVersion:
         output = (

--- a/test-runner/wasi_test_runner/runtime_adapter.py
+++ b/test-runner/wasi_test_runner/runtime_adapter.py
@@ -1,5 +1,5 @@
 import subprocess
-from shutil import which
+import sys
 from pathlib import Path
 from typing import Dict, NamedTuple, List
 
@@ -14,14 +14,10 @@ class RuntimeVersion(NamedTuple):
 class RuntimeAdapter:
     def __init__(self, adapter_path: str) -> None:
         self._adapter_path = self._abs(adapter_path)
-        # invoke the adapter with a configured shell runner. Default to bash.
-        # e.g. this is needed to point GHA's Windows runner to bash executable
-        self._shell = which('bash')
 
     def get_version(self) -> RuntimeVersion:
         output = (
-            # use the configured shell binary
-            subprocess.check_output([self._shell, self._adapter_path, "--version"], encoding="UTF-8")
+            subprocess.check_output([sys.executable, self._adapter_path, "--version"], encoding="UTF-8")
             .strip()
             .split(" ")
         )
@@ -36,8 +32,7 @@ class RuntimeAdapter:
     ) -> Output:
         args = (
             [
-                # use the configured shell binary
-                self._shell,
+                sys.executable,
                 self._adapter_path,
                 "--test-file",
                 self._abs(test_path),

--- a/test-runner/wasi_test_runner/runtime_adapter.py
+++ b/test-runner/wasi_test_runner/runtime_adapter.py
@@ -1,4 +1,6 @@
 import subprocess
+import sys
+import os
 from pathlib import Path
 from typing import Dict, NamedTuple, List
 
@@ -13,10 +15,14 @@ class RuntimeVersion(NamedTuple):
 class RuntimeAdapter:
     def __init__(self, adapter_path: str) -> None:
         self._adapter_path = self._abs(adapter_path)
+        # invoke the adapter with a configured shell runner. Default to bash.
+        # e.g. this is needed to point GHA's Windows runner to bash executable
+        self._shell = os.environ.get('TEST_SHELL_RUNNER', 'bash')
 
     def get_version(self) -> RuntimeVersion:
         output = (
-            subprocess.check_output([self._adapter_path, "--version"], encoding="UTF-8")
+            # use the configured shell binary
+            subprocess.check_output([self._shell, self._adapter_path, "--version"], encoding="UTF-8")
             .strip()
             .split(" ")
         )
@@ -31,6 +37,8 @@ class RuntimeAdapter:
     ) -> Output:
         args = (
             [
+                # use the configured shell binary
+                self._shell,
                 self._adapter_path,
                 "--test-file",
                 self._abs(test_path),


### PR DESCRIPTION
Improves over #1 with the fix proposed to upstream at https://github.com/WebAssembly/wasi-testsuite/pull/48
i.e. use `which('bash')`

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
